### PR TITLE
Expose getCurrentProduct in button class

### DIFF
--- a/app/code/community/Payone/PRA/Block/Button.php
+++ b/app/code/community/Payone/PRA/Block/Button.php
@@ -22,9 +22,9 @@
 class Payone_PRA_Block_Button extends Mage_Core_Block_Template
 {
     /**
-     * @return mixed
+     * @return Mage_Catalog_Model_Product|mixed
      */
-    protected function _getCurrentProduct()
+    public function getCurrentProduct()
     {
         return Mage::registry('current_product');
     }
@@ -34,7 +34,7 @@ class Payone_PRA_Block_Button extends Mage_Core_Block_Template
      */
     public function getCurrentProductId()
     {
-        $product = $this->_getCurrentProduct();
+        $product = $this->getCurrentProduct();
 
         return $product ? $product->getId() : null;
     }
@@ -44,8 +44,8 @@ class Payone_PRA_Block_Button extends Mage_Core_Block_Template
      */
     public function getCurrentProductType()
     {
-        $product = $this->_getCurrentProduct();
+        $product = $this->getCurrentProduct();
 
-        return $product ? $product->getTypeID() : null;
+        return $product ? $product->getTypeId() : null;
     }
 }


### PR DESCRIPTION
Expose the current product method in the button class so that developers can use the method in the template directly and don't have to implement it for themselves.

The reason behind this is, that one might not enable this feature for all products but only for products which match certain criterias (e.g. based on product attributes). With this change they can directly access the product object and perform the required checks.